### PR TITLE
Add AngleConverter util and unify rotation formula in MinuteDial

### DIFF
--- a/TimerStamp/Presentations/Timer/Components/MinuteDial.swift
+++ b/TimerStamp/Presentations/Timer/Components/MinuteDial.swift
@@ -90,14 +90,14 @@ struct MinuteDial: View {
         }
         .onChange(of: remainingTime) { _, newValue in
             if !isDragging {
-                rotation = remainingTime / 10.0
+                rotation = AngleConverter.secondsToDegrees(newValue)
             }
         }
         
         
     }
     func resetRotation() {
-        rotation = Double(durationMinutes) * 6
+        rotation = AngleConverter.minutesToDegrees(durationMinutes)
     }
     
 }

--- a/TimerStamp/Presentations/Timer/Utils/AngleConverter.swift
+++ b/TimerStamp/Presentations/Timer/Utils/AngleConverter.swift
@@ -1,0 +1,21 @@
+//
+//  AngleConverter.swift
+//  TimerStamp
+//
+//  타이머 시간(분/초) ↔ 원형 다이얼 각도(도) 변환 유틸리티.
+//  1분 = 6도 (360도 / 60분)
+//
+
+import Foundation
+
+enum AngleConverter {
+    /// 분을 다이얼 각도(도)로 변환합니다.
+    static func minutesToDegrees(_ minutes: Int) -> Double {
+        return Double(minutes) * 6.0
+    }
+
+    /// 초를 다이얼 각도(도)로 변환합니다.
+    static func secondsToDegrees(_ seconds: TimeInterval) -> Double {
+        return seconds / 10.0
+    }
+}

--- a/TimerStampTests/AngleConverterTests.swift
+++ b/TimerStampTests/AngleConverterTests.swift
@@ -1,0 +1,56 @@
+//
+//  AngleConverterTests.swift
+//  TimerStamp
+//
+//  [이슈 #7] MinuteDial 각도 변환 공식 불일치 해결을 위한 테스트.
+//  AngleConverter 타입이 존재하지 않으면 컴파일 실패 (TDD red 상태).
+//
+
+import XCTest
+@testable import TimerStamp
+
+final class AngleConverterTests: XCTestCase {
+
+    // MARK: - minutesToDegrees
+
+    func test_minutesToDegrees_1minute_returns6() {
+        XCTAssertEqual(AngleConverter.minutesToDegrees(1), 6.0)
+    }
+
+    func test_minutesToDegrees_25minutes_returns150() {
+        XCTAssertEqual(AngleConverter.minutesToDegrees(25), 150.0)
+    }
+
+    func test_minutesToDegrees_60minutes_returns360() {
+        XCTAssertEqual(AngleConverter.minutesToDegrees(60), 360.0)
+    }
+
+    func test_minutesToDegrees_0minutes_returns0() {
+        XCTAssertEqual(AngleConverter.minutesToDegrees(0), 0.0)
+    }
+
+    // MARK: - secondsToDegrees
+
+    func test_secondsToDegrees_60seconds_returns6() {
+        XCTAssertEqual(AngleConverter.secondsToDegrees(60), 6.0)
+    }
+
+    func test_secondsToDegrees_1500seconds_returns150() {
+        XCTAssertEqual(AngleConverter.secondsToDegrees(1500), 150.0)
+    }
+
+    func test_secondsToDegrees_0seconds_returns0() {
+        XCTAssertEqual(AngleConverter.secondsToDegrees(0), 0.0)
+    }
+
+    // MARK: - 일관성 검증 (두 함수가 동일한 결과를 반환해야 함)
+
+    func test_consistency_minutesAndSeconds_produceSameDegrees() {
+        for minutes in 1...59 {
+            let fromMinutes = AngleConverter.minutesToDegrees(minutes)
+            let fromSeconds = AngleConverter.secondsToDegrees(TimeInterval(minutes * 60))
+            XCTAssertEqual(fromMinutes, fromSeconds, accuracy: 0.001,
+                           "minutes=\(minutes): minutesToDegrees(\(fromMinutes)) != secondsToDegrees(\(fromSeconds))")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `AngleConverter` 유틸리티 추가 (`minutesToDegrees`, `secondsToDegrees`)
- `MinuteDial` 내 중복 인라인 공식을 `AngleConverter` 호출로 통일
- `AngleConverterTests` 추가 (두 함수 및 일관성 검증)

## Test plan
- [ ] `AngleConverterTests` 전체 통과 확인
- [ ] 분 설정 드래그 시 각도 변환 정상 동작 확인
- [ ] 타이머 실행 중 남은 시간 → 각도 변환 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)