### PR TITLE
Fix LiveActivity timer counting up after timer ends

### DIFF
--- a/TimerRemaining/LiveActivityView.swift
+++ b/TimerRemaining/LiveActivityView.swift
@@ -33,10 +33,13 @@ struct LiveActivityView: View {
             Spacer()
             // 남은 시간
             var remainingText: Text {
-                if contentState.isPaused || contentState.remainingTime <= 0 {
+                if contentState.isPaused {
                     return Text(timeString(from: contentState.remainingTime))
                 }
-                return Text(Date(timeIntervalSinceNow: contentState.remainingTime), style: .timer)
+                if let endDate = contentState.endDate {
+                    return Text(timerInterval: Date()...endDate, countsDown: true)
+                }
+                return Text(timeString(from: 0))
             }
             
             remainingText

--- a/TimerRemaining/TimerLiveActivityConfiguration.swift
+++ b/TimerRemaining/TimerLiveActivityConfiguration.swift
@@ -17,12 +17,10 @@ struct TimerLiveActivityConfiguration: Widget {
         } dynamicIsland: { context in
             let remaining = max(0, context.state.remainingTime)
             let timerText = {
-                if !context.state.isPaused && context.state.remainingTime > 0 {
-                    // 카운트다운 중 ➜ 자동 갱신
-                    Text(Date(timeIntervalSinceNow: remaining), style: .timer)
+                if context.state.isPaused || context.state.endDate == nil {
+                    Text(TimerLiveActivityConfiguration.format(seconds: Int(remaining)))
                 } else {
-                    // 0초 이하이거나 일시정지 ➜ "00:00" 등 고정 문자열
-                    Text(TimerLiveActivityConfiguration.format(seconds: Int(remaining)))   // 예: "00:00"
+                    Text(timerInterval: Date()...context.state.endDate!, countsDown: true)
                 }
             }()
             return DynamicIsland {
@@ -77,9 +75,9 @@ func progressView(context: ActivityViewContext<TimerAttributes>) -> some View {
 
 @ViewBuilder
 func timerText(context: ActivityViewContext<TimerAttributes>) -> some View {
-    if context.state.isPaused || context.state.remainingTime <= 0 {
-        Text(TimerLiveActivityConfiguration.format(seconds: Int(context.state.remainingTime)))
+    if context.state.isPaused || context.state.endDate == nil {
+        Text(TimerLiveActivityConfiguration.format(seconds: Int(max(0, context.state.remainingTime))))
     } else {
-        Text(Date(timeIntervalSinceNow: context.state.remainingTime), style: .timer)
+        Text(timerInterval: Date()...context.state.endDate!, countsDown: true)
     }
 }

--- a/TimerStamp/LiveActivity/LiveActivityManager.swift
+++ b/TimerStamp/LiveActivity/LiveActivityManager.swift
@@ -42,7 +42,9 @@ enum LiveActivityManager {
     static func end() {
         Task {
             for activity in Activity<TimerAttributes>.activities {
-                await activity.end(activity.content, dismissalPolicy: .immediate)
+                let finalState = TimerAttributes.ContentState(endDate: nil, isPaused: false, pausedRemainingTime: 0)
+                let content = ActivityContent(state: finalState, staleDate: nil)
+                await activity.end(content, dismissalPolicy: .immediate)
             }
         }
     }


### PR DESCRIPTION
## Summary

- `Text(Date(timeIntervalSinceNow: remainingTime), style: .timer)` 패턴을 `Text(timerInterval: Date()...endDate, countsDown: true)`로 교체 — 0에서 멈추고 카운트업으로 전환하지 않음
- `LiveActivityManager.end()`에서 `activity.content`(구 캐시 상태) 대신 `endDate: nil`인 명시적 종료 상태를 전달 — 종료 후 UI 제거 지연 구간에도 "00:00"이 표시됨
- 동일 패턴을 `LiveActivityView`, `TimerLiveActivityConfiguration` 두 곳 모두 수정

## 근본 원인

`.timer` 스타일은 앵커 날짜를 지나면 자동으로 카운트업으로 전환된다. 위젯이 렌더될 때 `remainingTime`을 읽어 앵커 날짜를 고정하는 방식이었기 때문에, 앱이 `end()`를 호출하기 전 앵커 날짜에 도달하면 LiveActivity가 살아있는 동안 계속 증가했다.

## Test plan

- [x] 기존 40개 테스트 전체 통과 (`fastlane test`)
- [x] 빌드 성공

Closes #없음 (CLAUDE.md 알려진 버그 항목)

🤖 Generated with [Claude Code](https://claude.com/claude-code)